### PR TITLE
Fix computing string length with indirect symbols from symbols files.

### DIFF
--- a/misc/strip.c
+++ b/misc/strip.c
@@ -3771,6 +3771,10 @@ enum bool *nlist_outofsync_with_dyldinfo)
 			    sp->seen = TRUE;
 			    len = strlen(strings + n_strx) + 1;
 			    new_ext_strsize += len;
+			    if ((n_type & N_TYPE) == N_INDR && n_value != 0) {
+				len = strlen(strings + n_value) + 1;
+				new_ext_strsize += len;
+			    }
 			    if((n_type & N_TYPE) == N_UNDF ||
 			       (n_type & N_TYPE) == N_PBUD)
 				new_nundefsym++;


### PR DESCRIPTION
Indirect symbols are copied twice to the 'p' variable, this is the second time:

https://github.com/apple-oss-distributions/cctools/blob/cbe977a1db16a2ca268124f6825535aeb670404c/misc/strip.c#L4217-L4228

This means we need to add the size of the indirect symbol to the size of the 'p' memory contents twice.

This seems to already be happening here:

https://github.com/apple-oss-distributions/cctools/blob/cbe977a1db16a2ca268124f6825535aeb670404c/misc/strip.c#L3820-L3823

and:

https://github.com/apple-oss-distributions/cctools/blob/cbe977a1db16a2ca268124f6825535aeb670404c/misc/strip.c#L3845-L3848

but one scenario (symbols files) was missing.

Ref: FB13327641 (contains test case).
Ref: https://github.com/xamarin/xamarin-macios/issues/19157